### PR TITLE
Use offsettop even when finding a named anchor tag on the page.

### DIFF
--- a/js/jquery.plusanchor.js
+++ b/js/jquery.plusanchor.js
@@ -62,7 +62,7 @@
                     // End onSlide callback
                     $(base.scrollEl).animate({
 
-                        scrollTop: $name.offset().top
+                        scrollTop: $name.offset().top + base.options.offsetTop
 
                     }, base.options.speed, base.options.easing);
 


### PR DESCRIPTION
I found that I needed to be able to specify the offset for all scroll-to elements, not just those found by id.

Cheers,
Pete
